### PR TITLE
Let ts compiler derive the correct `lib` config option values for us

### DIFF
--- a/source/lib/config.ts
+++ b/source/lib/config.ts
@@ -34,7 +34,7 @@ export default (pkg: {tsd?: RawConfig}, cwd: string): Config => {
 		compilerOptions: {
 			strict: true,
 			jsx: JsxEmit.React,
-			lib: ['es2017', 'dom', 'dom.iterable'].map(lib => `lib.${lib}.d.ts`),
+			lib: parseRawLibs(['es2017', 'dom', 'dom.iterable'], cwd),
 			module: ModuleKind.CommonJS,
 			target: ScriptTarget.ES2017,
 			esModuleInterop: true,
@@ -66,4 +66,8 @@ function parseCompilerConfigObject(compilerOptions: RawCompilerOptions, cwd: str
 		sys,
 		cwd
 	).options;
+}
+
+function parseRawLibs(libs: string[], cwd: string): string[] {
+	return parseCompilerConfigObject({lib: libs}, cwd).lib || [];
 }

--- a/source/test/fixtures/dom/index.test-d.ts
+++ b/source/test/fixtures/dom/index.test-d.ts
@@ -5,3 +5,7 @@ const parent = document.createElement('div');
 const child = document.createElement('p');
 
 expectType<void>(append(parent, child));
+
+const elementsCollection = document.getElementsByClassName('foo');
+expectType<HTMLCollectionOf<Element>>(elementsCollection);
+expectType<() => IterableIterator<Element>>(elementsCollection[Symbol.iterator]);

--- a/source/test/fixtures/lib-config/failure-missing-lib/package.json
+++ b/source/test/fixtures/lib-config/failure-missing-lib/package.json
@@ -1,3 +1,8 @@
 {
-	"name": "foo"
+	"name": "foo",
+	"tsd": {
+		"compilerOptions": {
+			"lib": []
+		}
+	}
 }

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -76,6 +76,15 @@ test('overridden config defaults to `strict` if `strict` is not explicitly overr
 	]);
 });
 
+test('fail if types are used from a lib that was not explicitly specified', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/lib-config/failure-missing-lib')});
+
+	verify(t, diagnostics, [
+		[1, 22, 'error', 'Cannot find name \'Window\'.', /failure-missing-lib\/index.d.ts$/],
+		[4, 11, 'error', 'Cannot find name \'Window\'.', /failure-missing-lib\/index.test-d.ts$/]
+	]);
+});
+
 test('allow specifying a lib as a triple-slash-reference', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/lib-config/lib-as-triple-slash-reference')});
 


### PR DESCRIPTION
- extend default `dom` lib tests
- restore the missing lib test